### PR TITLE
s/reimann/riemann/g

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ supporting the Pedestal-style structured logging interface.
 
 How about monitoring probe state across a distributed application?
 Rather than using Scribe or Splunk to aggregate and parse text
-strings, fire up [Reimann](http://reimann.io) and pipe probe state to
+strings, fire up [Riemann](http://riemann.io) and pipe probe state to
 it or use a scalable data store like HBase, MongoDB, Cassandra, or
 DynamoDB where historical probes can be indexed and analyzed as
 needed?  Cassandra is especially nice as you can have it automatically
@@ -276,7 +276,7 @@ Here are some opportunities to improve the library.
 * Add higher level targeted function tracing / collection facilities
   (e.g. trace 100 input/result vectors from function f or namespace ns)
 * Add metadata so we can inspect what functions are probed
-* Add a Reimann sink as probe.reimann usin the Reimann clojure client
+* Add a Riemann sink as probe.riemann usin the Riemann clojure client
 
 ### Major Tasks
 


### PR DESCRIPTION
Fix spelling of "Riemann" and associated link. 
